### PR TITLE
Extra path option to configDir. Useful to work with yarn workspaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 var path = require('path');
 
-module.exports = () => ({
+module.exports = (_, { extraPath }) => ({
   plugins: [
     [require('babel-plugin-dotenv'), {
       replacedModuleName: 'react-native-dotenv',
-      configDir: path.resolve(__dirname, "../../")
+      configDir: path.resolve(__dirname, `../../${extraPath || ''}`)
     }],
   ],
 });


### PR DESCRIPTION
When I was working in a monorepo, It was looking for dotenv files in the root of the repository. So, this helps to append an extraPath to find dotenv files. @hdwilber https://github.com/zetachang/react-native-dotenv/pull/72