### PR TITLE
Adding functionality to get values from system env

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,31 +28,32 @@ $ npm install metro-react-native-babel-preset --save-dev
 
 ## Usage
 
-Add your app configuration in an **.env** file.
+Add your app configuration in an **.env** file. Prefix your values with `$` to obtain from system env.
 
 ```
 API_KEY=lorem
 ANOTHER_CONFIG=foobar
+ANOTHER_API_KEY=$API_KEY_FROM_SYSTEM_ENV
 ```
 
 Now you can import it in your **.js** file.
 
 ```js
-import { API_KEY, ANOTHER_CONFIG } from 'react-native-dotenv'
+import { API_KEY, ANOTHER_CONFIG, ANOTHER_API_KEY } from 'react-native-dotenv'
 
-ApiClient.init(API_KEY, ANOTHER_CONFIG)
+ApiClient.init(API_KEY, ANOTHER_CONFIG, ANOTHER_API_KEY)
 ```
 
 ## How does it work?
 
-As you can see, it's implemented as a babel plugin. All referenced imported members are replaced as the values specified in the **.env** file.
+As you can see, it's implemented as a babel plugin. All referenced imported members are replaced as the values or environment variables specified in the **.env** file
 
-The example above will get compiled as below.
+The example above will get compiled as below, assuming your system environment variable `API_KEY_FROM_SYSTEM_ENV` is `this_value_is_from_system_env`
 
 ```js
-
-ApiClient.init('lorem', 'foobar')
+ApiClient.init('lorem', 'foobar', 'this_value_is_from_system_env')
 ```
+
 
 ## FAQ
 

--- a/babel-plugin-dotenv/README.md
+++ b/babel-plugin-dotenv/README.md
@@ -25,7 +25,7 @@ $ npm install babel-plugin-dotenv
 ```
 DB_HOST=localhost
 DB_USER=root
-DB_PASS=s1mpl3
+DB_PASS=$SECRET_KEY_FROM_SYSTEM_ENV
 ```
 
 In **whatever.js**
@@ -38,3 +38,7 @@ db.connect({
   password: DB_PASS
 });
 ```
+
+## Troubleshooting
+
+- Make sure the required system environment variables are properly exported in your build system / dev machine

--- a/babel-plugin-dotenv/test/fixtures/system-env/.babelrc
+++ b/babel-plugin-dotenv/test/fixtures/system-env/.babelrc
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    "babel-plugin-transform-es2015-modules-commonjs",
+    ["../../../", {
+      "replacedModuleName": "babel-dotenv",
+      "configDir": "test/fixtures/system-env"
+    }]
+  ]
+}

--- a/babel-plugin-dotenv/test/fixtures/system-env/.env
+++ b/babel-plugin-dotenv/test/fixtures/system-env/.env
@@ -1,0 +1,1 @@
+API_KEY=$ENV_API_KEY

--- a/babel-plugin-dotenv/test/fixtures/system-env/source.js
+++ b/babel-plugin-dotenv/test/fixtures/system-env/source.js
@@ -1,0 +1,2 @@
+import { API_KEY } from 'babel-dotenv';
+console.log(API_KEY);

--- a/babel-plugin-dotenv/test/test.js
+++ b/babel-plugin-dotenv/test/test.js
@@ -32,6 +32,21 @@ describe('myself in some tests', function() {
     expect(result.code).to.be('\'use strict\';\n\nconsole.log(\'abc123\');\nconsole.log(\'username\');')
   })
 
+  it('should load env from system env', function(){
+    process.env.ENV_API_KEY='THISISNOTASECRET'
+    var result = babel.transformFileSync('test/fixtures/system-env/source.js')
+    expect(result.code).to.be('\'use strict\';\n\nconsole.log(\'THISISNOTASECRET\');')
+  })
+
+  it('should throw if imported system env is not present', function() {
+    delete process.env.ENV_API_KEY
+    expect(function(){
+      babel.transformFileSync('test/fixtures/system-env/source.js')
+    }).to.throwException(function (e) {
+      expect(e.message).to.contain("Trying to use system environment variable ");
+    });
+  });
+
   it('should load empty variable as empty string ', function(){
     var result = babel.transformFileSync('test/fixtures/empty-values/source.js')
     expect(result.code).to.be('\'use strict\';\n\nconsole.log(\'abc123\');\nconsole.log(\'username\');\nconsole.log(\'\');')


### PR DESCRIPTION
Thanks for the awesome library that we use for our app. We found this particular extension useful for us and could benefit others too.
This PR extends react-native-dotenv to use the values from system environment variables that are specified in .env. files.

This eliminates the need of hardcoding the important/secret values into .env files when they are already available via system environment. This adds a lot of value to organizations that uses monolithic repositories where the API_KEYs and SECRETs are shared between apps in same repo.

@srbkrishnan @anova-culinary
https://github.com/zetachang/react-native-dotenv/pull/59